### PR TITLE
docs: add installation and configuration guides for both Go and Rust implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,56 @@
 # Smart-Git
 
-基于HertZ和Go-Git实现的git clone (smart http) 转发
+Smart-Git 是一个高性能的 Git Smart HTTP 转发与缓存服务，旨在加速对 GitHub 等上游仓库的访问，并提供本地镜像缓存。
 
-## 特点
+本项目提供两种语言实现，它们在功能和 API 上保持高度一致，可以根据部署环境灵活选择。
 
-- 基于HertZ netpoll 构建, 高性能可扩展
-- 基于Go-Git实现git相关功能
-- 使用轻量级数据库BoltDB实现相关元数据管理
+## 项目特点
+
+### Go 版本
+- **高性能**: 基于 [Touka](https://github.com/infinite-iroha/touka) 框架构建，具备优秀的吞吐能力与扩展性。
+- **纯 Go 实现**: 使用 [Go-Git](https://github.com/go-git/go-git) 处理 Git 协议，无 CGO 依赖。
+- **轻量存储**: 使用 [BoltDB](https://go.etcd.io/bbolt) 管理元数据，单文件数据库，部署简便。
+
+### Rust 版本 (`smart-git-rs`)
+- **现代异步**: 基于 [Axum](https://github.com/tokio-rs/axum) 和 [Tokio](https://github.com/tokio-rs/tokio) 栈，资源占用低且并发性强。
+- **稳健的 Git 引擎**: 采用 [Gix](https://github.com/Byron/gitoxide) (Gitoxide) 引擎，提供更快的克隆与同步速度。
+- **自动刷新**: 引入后台扫描任务，根据 TTL 自动更新过期仓库。
+- **标准存储**: 使用 SQLite 管理元数据，方便进行数据维护。
 
 ## 部署
 
-Docker Compose 安装 [docker-compose.yml](https://github.com/WJQSERVER-STUDIO/smart-git/blob/25w02a/docker/compose/docker-compose.yml)
+### Docker Compose 部署
+
+你可以直接使用以下 Compose 文件快速部署：
+
+- Go 版本: [docker/compose/docker-compose.yml](docker/compose/docker-compose.yml)
+- Rust 版本: [docker/compose/docker-compose-rs.yml](docker/compose/docker-compose-rs.yml)
+
+更完整的安装步骤见 [docs/install.md](docs/install.md)。
 
 ## 配置文件
 
-```toml
-[server]
-host = "0.0.0.0" # 监听地址
-port = 8080  # 监听端口
-baseDir = "/data/smart-git/repos" # 缓存文件夹
-memLimit = 0 #MB 内存使用限制
+Smart-Git 推荐使用 **WANF** 配置格式，同时也兼容 **TOML**。程序启动时会优先寻找 `.wanf` 配置文件。
 
-[log]
-logfilepath = "/data/smart-git/log/smart-git.log"  # 日志存储位置
-maxlogsize = 5 # MB
-level = "info" # dump, debug, info, warn, error, none
+Go 与 Rust 两个实现的示例配置、TOML/WANF 对照和字段说明见 [docs/config.md](docs/config.md)。
 
-[Database]
-path = "/data/smart-git/db/smart-git.db" # 数据库存储位置
+## API 兼容性
 
-[cache]
-expire = "1h" # 缓存过期时间
-expireEx = "10m" # 过期延长时间(当hash检查后发现未过期, 增加的时间)
-```
+两套实现在管理接口上保持互换性，均支持 **JSON** 和 **WANF** 响应格式。
+
+- `GET /healthz`: 服务健康检查。
+- `GET /api/db/data`: 返回当前所有缓存仓库的详细记录。
+- `GET /api/db/sum`: 返回仓库的拉取统计信息（克隆次数、请求次数）。
+- `POST /api/cache/{owner}/{repo}/sync`: (仅 Rust 版) 手动触发指定仓库的同步。
 
 ## 许可
 
-本项目使用 WJQserver Studio 开源许可证 v2.0
+本项目使用 **WJQserver Studio 开源许可证 v2.0**。
 
-## 调用
+## 参考与致谢
 
-使用以下框架/实现
-[HertZ](https://github.com/cloudwego/hertz)
-[Go-Git](https://github.com/go-git/go-git)
-[BboltDB](https://go.etcd.io/bbolt)
-[toml](https://github.com/BurntSushi/toml)
-[logger](github.com/WJQSERVER-STUDIO/go-utils/logger)
-
-参考以下仓库实现Git Smart Http
-[erred/gitreposerver](https://github.com/erred/gitreposerver)
+- [Touka](https://github.com/infinite-iroha/touka)
+- [Go-Git](https://github.com/go-git/go-git)
+- [Gix (Gitoxide)](https://github.com/Byron/gitoxide)
+- [WANF](https://github.com/WJQSERVER/wanf)
+- [erred/gitreposerver](https://github.com/erred/gitreposerver) (Smart HTTP 实现参考)

--- a/docker/compose/docker-compose-rs.yml
+++ b/docker/compose/docker-compose-rs.yml
@@ -1,0 +1,11 @@
+version: '3.9'
+services:
+    smart-git-rs:
+        image: 'wjqserver/smart-git-rs:latest'
+        restart: always
+        volumes:
+            - './smart-git-rs/config:/data/smart-git/config'
+            - './smart-git-rs/repos:/data/smart-git/repos'
+            - './smart-git-rs/db:/data/smart-git/db'
+        ports:
+            - '8080:8080'

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,7 +44,7 @@ logfilepath = "/data/smart-git/log/smart-git.log"
 maxlogsize = 5
 level = "info"
 
-[Database]
+[database]
 path = "/data/smart-git/db/smart-git.db"
 
 [cache]

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,124 @@
+# 配置指南
+
+Smart-Git 推荐使用 **WANF** 配置格式，同时也兼容 **TOML**。系统启动时会优先查找 `.wanf` 后缀的配置文件。
+
+---
+
+## Go 版本配置
+
+### WANF 格式 (`config.wanf`)
+```wanf
+Server {
+  host = "0.0.0.0"
+  port = 8080
+  baseDir = "/data/smart-git/repos"
+  memLimit = 0
+}
+
+Log {
+  logfilepath = "/data/smart-git/log/smart-git.log"
+  maxlogsize = 5
+  level = "info"
+}
+
+Database {
+  path = "/data/smart-git/db/smart-git.db"
+}
+
+Cache {
+  expire = 1h
+  expireEx = 10m
+}
+```
+
+### TOML 格式 (`config.toml`)
+```toml
+[server]
+host = "0.0.0.0"
+port = 8080
+baseDir = "/data/smart-git/repos"
+memLimit = 0
+
+[log]
+logfilepath = "/data/smart-git/log/smart-git.log"
+maxlogsize = 5
+level = "info"
+
+[Database]
+path = "/data/smart-git/db/smart-git.db"
+
+[cache]
+expire = "1h"
+expireEx = "10m"
+```
+
+---
+
+## Rust 版本配置 (`smart-git-rs`)
+
+### WANF 格式 (`config.wanf`)
+```wanf
+server {
+  host = "0.0.0.0"
+  port = 8080
+}
+
+database {
+  path = "/data/smart-git/db/smart-git.db"
+}
+
+cache {
+  repo_dir = "/data/smart-git/repos"
+  refresh_ttl_secs = 300
+  refresh_scan_secs = 60
+}
+
+upstream {
+  github_base = "https://github.com"
+}
+```
+
+### TOML 格式 (`config.toml`)
+```toml
+[server]
+host = "0.0.0.0"
+port = 8080
+
+[database]
+path = "/data/smart-git/db/smart-git.db"
+
+[cache]
+repo_dir = "/data/smart-git/repos"
+refresh_ttl_secs = 300
+refresh_scan_secs = 60
+
+[upstream]
+github_base = "https://github.com"
+```
+
+---
+
+## 配置项详解
+
+### Server / server (服务器配置)
+- **host**: 服务器监听的 IP 地址。默认为 `0.0.0.0`（监听所有网卡）。
+- **port**: 服务器监听的 TCP 端口。默认为 `8080`。
+- **baseDir / repo_dir**: 本地 Git 仓库缓存的根目录。程序会在此目录下按 `user/repo.git` 的结构存储 bare 仓库。
+- **memLimit (仅 Go)**: 设置 Go 运行时的内存限制（单位：MB）。若大于 0，则会调用 `debug.SetMemoryLimit`。
+
+### Log / log (日志配置 - 仅 Go 支持详细配置)
+- **logfilepath**: 日志文件的存储路径。
+- **maxlogsize**: 单个日志文件的最大大小（单位：MB）。
+- **level**: 日志输出级别。支持 `dump`, `debug`, `info`, `warn`, `error`, `none`。
+
+### Database / database (数据库配置)
+- **path**: 数据库文件路径。Go 版本使用 BoltDB (单文件 KV)，Rust 版本使用 SQLite。
+
+### Cache / cache (缓存策略配置)
+- **expire (Go)**: 仓库缓存的有效期（如 `1h`, `30m`）。过期后的请求将触发与上游同步。
+- **expireEx (Go)**: 延展时间。当检查发现上游未更新（Hash 未变）时，为缓存增加的额外有效期。
+- **refresh_ttl_secs (Rust)**: 缓存有效期（单位：秒）。
+- **refresh_scan_secs (Rust)**: 后台同步任务的扫描频率（单位：秒）。程序会定期扫描并刷新已过期的仓库。
+
+### Upstream / upstream (上游配置 - 仅 Rust)
+- **github_base**: 上游 Git 托管平台的基准 URL。默认为 `https://github.com`。

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,87 @@
+# 安装指南
+
+Smart-Git 提供多种部署方式，推荐使用 Docker 部署。
+
+---
+
+## 1. 使用 Docker Compose 部署 (推荐)
+
+这是最便捷的部署方式。
+
+### Go 版本
+1. 下载 `docker/compose/docker-compose.yml`：
+   ```bash
+   wget https://raw.githubusercontent.com/WJQSERVER-STUDIO/smart-git/main/docker/compose/docker-compose.yml
+   ```
+
+2. 启动服务：
+   ```bash
+   docker compose up -d
+   ```
+
+### Rust 版本 (`smart-git-rs`)
+1. 下载 `docker/compose/docker-compose-rs.yml`：
+   ```bash
+   wget https://raw.githubusercontent.com/WJQSERVER-STUDIO/smart-git/main/docker/compose/docker-compose-rs.yml
+   ```
+
+2. 启动服务：
+   ```bash
+   docker compose -f docker-compose-rs.yml up -d
+   ```
+
+---
+
+## 2. 源码编译安装
+
+### Go 版本
+环境要求：Go 1.26+
+
+1. 克隆并进入项目：
+   ```bash
+   git clone https://github.com/WJQSERVER-STUDIO/smart-git.git
+   cd smart-git
+   ```
+
+2. 编译可执行文件：
+   ```bash
+   go build -o smart-git .
+   ```
+
+3. 使用指定配置运行：
+   ```bash
+   ./smart-git -c config/config.wanf
+   ```
+
+### Rust 版本 (`smart-git-rs`)
+环境要求：Rust 1.94+
+
+1. 进入 Rust 目录：
+   ```bash
+   cd smart-git-rs
+   ```
+
+2. 编译 release 版本：
+   ```bash
+   cargo build --release
+   ```
+
+3. 使用指定配置运行：
+   ```bash
+   ./target/release/smart-git-rs -c config.wanf
+   ```
+
+---
+
+## 3. 运行环境说明
+
+- **磁盘空间**: 取决于缓存仓库的总量。
+- **网络访问**: 需确保服务器能正常连接 GitHub (或配置的上游地址)。
+- **持久化**: 建议将仓库根目录及数据库目录挂载至持久化卷。
+
+---
+
+## 4. 注意事项
+
+- **数据库路径**: 运行前请确保配置文件中的数据库父目录存在，或者具有创建目录的权限。
+- **WANF 优先**: 两个版本均支持 `-c` 参数指定配置文件路径。若未指定，系统将尝试加载默认路径下的 `.wanf` 或 `.toml` 文件。


### PR DESCRIPTION
## Summary

- Add `docs/install.md` with Docker Compose and source build instructions
- Add `docs/config.md` with WANF/TOML configuration reference
- Add `docker/compose/docker-compose-rs.yml` for Rust version deployment
- Simplify README to link to documentation instead of inline config examples

This PR ports the documentation content from PR #39 while dropping the outdated workflow changes that caused merge conflicts.