### PR TITLE
build: update Rust dependencies

### DIFF
--- a/smart-git-rs/Cargo.lock
+++ b/smart-git-rs/Cargo.lock
@@ -222,9 +222,9 @@ checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "gitserver-core"
-version = "0.0.1"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7adf0f5cb76817fa8ba76de2772354924dbf77e2dca7902c03d099d8abd66d"
+checksum = "a1602ba9d763304aa30d74bb3f3005be51c4b6db8312f7345f8d48f44f0c4825"
 dependencies = [
  "bytes",
  "gix 0.80.0",
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "gitserver-http"
-version = "0.0.1"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613555de706048fc4b05f436f535a3cb2a533959b120d5655ef88656ff8e30a3"
+checksum = "390edd4883da94809ea31bf6b768a06ef4fb435f62ab5f8e1071ede36cce2ec0"
 dependencies = [
  "axum",
  "base64",
@@ -2114,6 +2114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hashlink"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,12 +2257,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2336,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2373,14 +2379,14 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2646,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -3085,9 +3091,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -3377,9 +3383,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3390,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3400,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3413,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]

--- a/smart-git-rs/Cargo.toml
+++ b/smart-git-rs/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 anyhow = "1"
 axum = { version = "0.8.8", features = ["macros"] }
 clap = { version = "4.6.0", features = ["derive"] }
-gitserver-core = "0.0.1"
-gitserver-http = "0.0.1"
+gitserver-core = "0.0.3"
+gitserver-http = "0.0.3"
 gix = { version = "0.81.0", features = ["blocking-network-client"] }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/smart-git-rs/src/http/admin.rs
+++ b/smart-git-rs/src/http/admin.rs
@@ -122,6 +122,13 @@ impl ApiError {
         }
     }
 
+    fn service_unavailable(error: impl Into<anyhow::Error>) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            error: error.into(),
+        }
+    }
+
     fn internal(error: impl Into<anyhow::Error>) -> Self {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
@@ -149,6 +156,9 @@ fn api_error_from_git(error: GitHttpAppError) -> ApiError {
     match error {
         GitHttpAppError::NotFound(message) => ApiError::not_found(anyhow::anyhow!(message)),
         GitHttpAppError::BadRequest(message) => ApiError::bad_request(anyhow::anyhow!(message)),
+        GitHttpAppError::ServiceUnavailable(message) => {
+            ApiError::service_unavailable(anyhow::anyhow!(message))
+        }
         GitHttpAppError::Internal(message) => ApiError::internal(anyhow::anyhow!(message)),
         GitHttpAppError::Unauthorized => {
             ApiError::unauthorized(anyhow::anyhow!("authentication required"))


### PR DESCRIPTION
## Summary
- upgrade `gitserver-core` and `gitserver-http` from `0.0.1` to `0.0.3`
- refresh `smart-git-rs/Cargo.lock` to pick up the latest compatible Rust dependency updates
- map the new `ServiceUnavailable` gitserver error to HTTP 503 in the admin API

## Testing
- cargo test --manifest-path smart-git-rs/Cargo.toml