### PR TITLE
build: update Rust dependencies

### DIFF
--- a/smart-git-rs/Cargo.toml
+++ b/smart-git-rs/Cargo.toml
@@ -24,3 +24,15 @@ wanf = "0.0.1"
 
 [dev-dependencies]
 tempfile = "3"
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false
+
+[profile.test]
+debug = "line-tables-only"
+
+[profile.test.package."*"]
+debug = false


### PR DESCRIPTION
## Summary
- upgrade `gitserver-core` and `gitserver-http` to `0.0.3` and refresh the Rust lockfile
- map the new `ServiceUnavailable` gitserver error to HTTP 503 in the admin API
- reduce local Rust dev/test debug info by keeping line tables only for workspace crates and disabling dependency debug info

## Testing
- cargo test --manifest-path smart-git-rs/Cargo.toml