### PR TITLE
build: unify release tags across Go and Rust

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -2,9 +2,14 @@ name: Release Go
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to publish (for example v1.0.6)
+        required: true
+        type: string
   push:
     tags:
-      - "go/v*"
+      - "v*"
 
 permissions:
   contents: write
@@ -22,11 +27,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref }}
 
       - name: Derive release metadata
+        env:
+          INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || '' }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#go/}"
+          TAG="${INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          VERSION="$TAG"
           echo "TAG=$TAG" >> "$GITHUB_ENV"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
@@ -72,11 +84,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref }}
 
       - name: Derive release metadata
+        env:
+          INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || '' }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#go/}"
+          TAG="${INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          VERSION="$TAG"
           echo "TAG=$TAG" >> "$GITHUB_ENV"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -2,9 +2,14 @@ name: Release Rust
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to publish (for example v1.0.6)
+        required: true
+        type: string
   push:
     tags:
-      - "rust/v*"
+      - "v*"
 
 permissions:
   contents: write
@@ -20,11 +25,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref }}
 
       - name: Derive release metadata
+        env:
+          INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || '' }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#rust/}"
+          TAG="${INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          VERSION="$TAG"
           echo "TAG=$TAG" >> "$GITHUB_ENV"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
@@ -66,11 +78,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref }}
 
       - name: Derive release metadata
+        env:
+          INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || '' }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#rust/}"
+          TAG="${INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          VERSION="$TAG"
           echo "TAG=$TAG" >> "$GITHUB_ENV"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Smart-Git 是一个高性能的 Git Smart HTTP 转发与缓存服务，旨在加
 - **轻量存储**: 使用 [BoltDB](https://go.etcd.io/bbolt) 管理元数据，单文件数据库，部署简便。
 
 ### Rust 版本 (`smart-git-rs`)
+- **Git 协议与 HTTP 基础能力**: 基于 [gitserver](https://github.com/WJQSERVER/gitserver) 提供 Rust 版本的 Git 协议处理与 HTTP 层支持。
 - **现代异步**: 基于 [Axum](https://github.com/tokio-rs/axum) 和 [Tokio](https://github.com/tokio-rs/tokio) 栈，资源占用低且并发性强。
 - **稳健的 Git 引擎**: 采用 [Gix](https://github.com/Byron/gitoxide) (Gitoxide) 引擎，提供更快的克隆与同步速度。
 - **自动刷新**: 引入后台扫描任务，根据 TTL 自动更新过期仓库。
@@ -52,5 +53,6 @@ Go 与 Rust 两个实现的示例配置、TOML/WANF 对照和字段说明见 [do
 - [Touka](https://github.com/infinite-iroha/touka)
 - [Go-Git](https://github.com/go-git/go-git)
 - [Gix (Gitoxide)](https://github.com/Byron/gitoxide)
+- [gitserver](https://github.com/WJQSERVER/gitserver) (Rust 版本的 Git 协议与 HTTP 层能力支持)
 - [WANF](https://github.com/WJQSERVER/wanf)
 - [erred/gitreposerver](https://github.com/erred/gitreposerver) (Smart HTTP 实现参考)


### PR DESCRIPTION
## Summary
- switch both release workflows to a shared `v*` tag scheme so Go and Rust assets can publish into the same GitHub release
- require an explicit `release_tag` input for manual release dispatches so manual runs target a specific tag instead of the current branch
- add gitserver acknowledgements to the Rust feature list and the README references section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 发布工作流现支持手动指定发布标签，增强版本管理灵活性。

* **文档**
  * 更新Rust版本技术特性和参考链接。

* **杂务**
  * 优化发布触发规则和版本派生逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->